### PR TITLE
Removal of the context menu closing delay

### DIFF
--- a/src/contextmenu.js
+++ b/src/contextmenu.js
@@ -169,9 +169,7 @@ jSuites.contextmenu = (function(el, options) {
     }
 
     el.addEventListener('blur', function(e) {
-        setTimeout(function() {
-            obj.close();
-        }, 120);
+        obj.close();
     });
 
     if (! jSuites.contextmenu.hasEvents) {


### PR DESCRIPTION
I started investigating on this behaviour when, once I started right-clicking on the screen multiple times, I noticed that the context menu was correctly shown only half of the times.  
The other half of the times, it only appears for a split second and then disappears.

That's why...  
Once the context menu loses focus, a 120ms timeout is instantiated to close it.  
So, if you open the context menu and then right-click elsewhere on the page to show it again, it correctly closes the first one, opens the second one and then, after 120ms, it wrongly closes the second one.

And, of course...  
In my humble opinion, even if it worked correctly, it's an unexpected behaviour.  
No other program waits some time before closing the context menu... It seems that it's running slow for some unknown reason.