### PR TITLE
prefix CSS animations and custom properties

### DIFF
--- a/src/plugins/animation.js
+++ b/src/plugins/animation.js
@@ -26,17 +26,17 @@ function Animation() {
     
     Component.slideLeft = function (element, direction, done) {
         if (direction == true) {
-            element.classList.add('slide-left-in');
+            element.classList.add('jslide-left-in');
             setTimeout(function () {
-                element.classList.remove('slide-left-in');
+                element.classList.remove('jslide-left-in');
                 if (typeof (done) == 'function') {
                     done();
                 }
             }, 400);
         } else {
-            element.classList.add('slide-left-out');
+            element.classList.add('jslide-left-out');
             setTimeout(function () {
-                element.classList.remove('slide-left-out');
+                element.classList.remove('jslide-left-out');
                 if (typeof (done) == 'function') {
                     done();
                 }
@@ -46,17 +46,17 @@ function Animation() {
     
     Component.slideRight = function (element, direction, done) {
         if (direction === true) {
-            element.classList.add('slide-right-in');
+            element.classList.add('jslide-right-in');
             setTimeout(function () {
-                element.classList.remove('slide-right-in');
+                element.classList.remove('jslide-right-in');
                 if (typeof (done) == 'function') {
                     done();
                 }
             }, 400);
         } else {
-            element.classList.add('slide-right-out');
+            element.classList.add('jslide-right-out');
             setTimeout(function () {
-                element.classList.remove('slide-right-out');
+                element.classList.remove('jslide-right-out');
                 if (typeof (done) == 'function') {
                     done();
                 }
@@ -66,17 +66,17 @@ function Animation() {
     
     Component.slideTop = function (element, direction, done) {
         if (direction === true) {
-            element.classList.add('slide-top-in');
+            element.classList.add('jslide-top-in');
             setTimeout(function () {
-                element.classList.remove('slide-top-in');
+                element.classList.remove('jslide-top-in');
                 if (typeof (done) == 'function') {
                     done();
                 }
             }, 400);
         } else {
-            element.classList.add('slide-top-out');
+            element.classList.add('jslide-top-out');
             setTimeout(function () {
-                element.classList.remove('slide-top-out');
+                element.classList.remove('jslide-top-out');
                 if (typeof (done) == 'function') {
                     done();
                 }
@@ -86,17 +86,17 @@ function Animation() {
     
     Component.slideBottom = function (element, direction, done) {
         if (direction === true) {
-            element.classList.add('slide-bottom-in');
+            element.classList.add('jslide-bottom-in');
             setTimeout(function () {
-                element.classList.remove('slide-bottom-in');
+                element.classList.remove('jslide-bottom-in');
                 if (typeof (done) == 'function') {
                     done();
                 }
             }, 400);
         } else {
-            element.classList.add('slide-bottom-out');
+            element.classList.add('jslide-bottom-out');
             setTimeout(function () {
-                element.classList.remove('slide-bottom-out');
+                element.classList.remove('jslide-bottom-out');
                 if (typeof (done) == 'function') {
                     done();
                 }
@@ -106,9 +106,9 @@ function Animation() {
     
     Component.fadeIn = function (element, done) {
         element.style.display = '';
-        element.classList.add('fade-in');
+        element.classList.add('jfade-in');
         setTimeout(function () {
-            element.classList.remove('fade-in');
+            element.classList.remove('jfade-in');
             if (typeof (done) == 'function') {
                 done();
             }
@@ -116,10 +116,10 @@ function Animation() {
     }
     
     Component.fadeOut = function (element, done) {
-        element.classList.add('fade-out');
+        element.classList.add('jfade-out');
         setTimeout(function () {
             element.style.display = 'none';
-            element.classList.remove('fade-out');
+            element.classList.remove('jfade-out');
             if (typeof (done) == 'function') {
                 done();
             }

--- a/src/plugins/slider.js
+++ b/src/plugins/slider.js
@@ -15,7 +15,7 @@ export default function Slider(el, options) {
 
     if (! el.classList.contains('jslider')) {
         el.classList.add('jslider');
-        el.classList.add('junselectable');
+        el.classList.add('unselectable');
 
         if (obj.options.height) {
             el.style.minHeight = parseInt(obj.options.height) + 'px';

--- a/src/plugins/slider.js
+++ b/src/plugins/slider.js
@@ -15,7 +15,7 @@ export default function Slider(el, options) {
 
     if (! el.classList.contains('jslider')) {
         el.classList.add('jslider');
-        el.classList.add('unselectable');
+        el.classList.add('junselectable');
 
         if (obj.options.height) {
             el.style.minHeight = parseInt(obj.options.height) + 'px';

--- a/src/style/animation.css
+++ b/src/style/animation.css
@@ -38,185 +38,185 @@
 }
 
 /** Animations **/
-.fade-in {
-    animation: fade-in 2s forwards;
+.jfade-in {
+    animation: jfade-in 2s forwards;
 }
 
-.fade-out {
-    animation: fade-out 1s forwards;
+.jfade-out {
+    animation: jfade-out 1s forwards;
 }
 
-.slide-left-in {
+.jslide-left-in {
     position: relative;
-    animation: slide-left-in 0.4s forwards;
+    animation: jslide-left-in 0.4s forwards;
 }
 
-.slide-left-out {
+.jslide-left-out {
     position: relative;
-    animation: slide-left-out 0.4s forwards;
+    animation: jslide-left-out 0.4s forwards;
 }
 
-.slide-right-in {
+.jslide-right-in {
     position: relative;
-    animation: slide-right-in 0.4s forwards;
+    animation: jslide-right-in 0.4s forwards;
 }
 
-.slide-right-out {
+.jslide-right-out {
     position: relative;
-    animation: slide-right-out 0.4s forwards;
+    animation: jslide-right-out 0.4s forwards;
 }
 
-.slide-top-in {
+.jslide-top-in {
     position: relative;
-    animation: slide-top-in 0.4s forwards;
+    animation: jslide-top-in 0.4s forwards;
 }
 
-.slide-top-out {
+.jslide-top-out {
     position: relative;
-    animation: slide-top-out 0.2s forwards;
+    animation: jslide-top-out 0.2s forwards;
 }
 
-.slide-bottom-in {
+.jslide-bottom-in {
     position: relative;
-    animation: slide-bottom-in 0.4s forwards;
+    animation: jslide-bottom-in 0.4s forwards;
 }
 
-.slide-bottom-out {
+.jslide-bottom-out {
     position: relative;
-    animation: slide-bottom-out 0.1s forwards;
+    animation: jslide-bottom-out 0.1s forwards;
 }
 
-.slide-left-in > div {
+.jslide-left-in > div {
     -webkit-transform: translateZ(0px);
     -webkit-transform: translate3d(0,0,0);
 }
 
-.slide-left-out > div {
+.jslide-left-out > div {
     -webkit-transform: translateZ(0px);
     -webkit-transform: translate3d(0,0,0);
 }
 
-.slide-right-in > div {
+.jslide-right-in > div {
     -webkit-transform: translateZ(0px);
     -webkit-transform: translate3d(0,0,0);
 }
 
-.slide-right-out > div {
+.jslide-right-out > div {
     -webkit-transform: translateZ(0px);
     -webkit-transform: translate3d(0,0,0);
 }
 
-.spin {
-    animation: spin 2s infinite linear;
+.jspin {
+    animation: jspin 2s infinite linear;
 }
 
 /** Fadein and Fadeout **/
-@keyframes fade-in {
+@keyframes jfade-in {
     0% { opacity: 0; }
     100% { opacity: 100; }
 }
 
-@-webkit-keyframes fade-in {
+@-webkit-keyframes jfade-in {
     0% { opacity: 0; }
     100% { opacity: 100; }
 }
 
-@keyframes fade-out {
+@keyframes jfade-out {
     0% { opacity: 100; }
     100% { opacity: 0; }
 }
 
-@-webkit-keyframes fade-out {
+@-webkit-keyframes jfade-out {
     0% { opacity: 100; }
     100% { opacity: 0; }
 }
 
 /** Keyframes Left to Right **/
-@keyframes slide-left-in {
+@keyframes jslide-left-in {
     0% { left: -100%; }
     100% { left: 0%; }
 }
 
-@-webkit-keyframes slide-left-in {
+@-webkit-keyframes jslide-left-in {
     0% { left: -100%; }
     100% { left: 0%; }
 }
     
-@keyframes slide-left-out {
+@keyframes jslide-left-out {
     0% { left: 0%; }
     100% { left: -100%; }
 }
 
-@-webkit-keyframes slide-left-out {
+@-webkit-keyframes jslide-left-out {
     0% { left: 0%; }
     100% { left: -100%; }
 }
 
 /** Keyframes Right to Left **/
-@keyframes slide-right-in {
+@keyframes jslide-right-in {
     0% { left: 100%; }
     100% { left: 0%; }
 }
 
-@-webkit-keyframes slide-right-in
+@-webkit-keyframes jslide-right-in
 {
     0% { left: 100%; }
     100% { left: 0%; }
 }
     
-@keyframes slide-right-out {
+@keyframes jslide-right-out {
     0% { left: 0%; }
     100% { left: 100%; }
 }
 
-@-webkit-keyframes slide-right-out {
+@-webkit-keyframes jslide-right-out {
     0% { left: 0%; }
     100% { left: 100%; }
 }
 
 /** Keyframes Top to Bottom **/
-@keyframes slide-top-in {
+@keyframes jslide-top-in {
     0% { transform: translateY(-100%); }
     100% { transform: translateY(0%); }
 }
 
-@-webkit-keyframes slide-top-in {
+@-webkit-keyframes jslide-top-in {
     0% { transform: translateY(-100%); }
     100% { -webkit-transform: translateY(0%); }
 }
     
-@keyframes slide-top-out {
+@keyframes jslide-top-out {
     0% { transform: translateY(0%); }
     100% { transform: translateY(-100%); }
 }
 
-@-webkit-keyframes slide-top-out {
+@-webkit-keyframes jslide-top-out {
     0% { -webkit-transform: translateY(0%); }
     100% { -webkit-transform: translateY(-100%); }
 }
 
 /** Keyframes Bottom to Top **/
-@keyframes slide-bottom-in {
+@keyframes jslide-bottom-in {
     0% { transform: translateY(100%); }
     100% { transform: translateY(0%); }
 }
 
-@-webkit-keyframes slide-bottom-in {
+@-webkit-keyframes jslide-bottom-in {
     0% { transform: translateY(100%); }
     100% { -webkit-transform: translateY(0%); }
 }
     
-@keyframes slide-bottom-out {
+@keyframes jslide-bottom-out {
     0% { transform: translateY(0%); }
     100% { transform: translateY(100%); }
 }
 
-@-webkit-keyframes slide-bottom-out {
+@-webkit-keyframes jslide-bottom-out {
     0% { -webkit-transform: translateY(0%); }
     100% { -webkit-transform: translateY(100%); }
 }
 
-@-webkit-keyframes spin {
+@-webkit-keyframes jspin {
     from {
         -webkit-transform:rotate(0deg);
     }
@@ -225,7 +225,7 @@
     }
 }
 
-@keyframes spin {
+@keyframes jspin {
     from {
         transform:rotate(0deg);
     }

--- a/src/style/buttons.css
+++ b/src/style/buttons.css
@@ -97,8 +97,8 @@
 }
 
 .jbuttons-group.mobile .jbutton {
-    border-color: var(--active-color);
-    color: var(--active-color);
+    border-color: var(--jactive-color);
+    color: var(--jactive-color);
     padding:4px;
     padding-left:25px;
     padding-right:25px;
@@ -109,7 +109,7 @@
 
 .jbuttons-group .jbutton.selected {
     color: white;
-    background-color: var(--active-color);
+    background-color: var(--jactive-color);
 }
 
 .jbuttons-group .jbutton:first-child {

--- a/src/style/calendar.css
+++ b/src/style/calendar.css
@@ -157,7 +157,7 @@
 .jcalendar-reset, .jcalendar-confirm {
     text-transform:uppercase;
     cursor:pointer;
-    color: var(--active-color);
+    color: var(--jactive-color);
 }
 
 .jcalendar-controls {

--- a/src/style/color.css
+++ b/src/style/color.css
@@ -40,7 +40,7 @@
 .jcolor-controls div {
     flex: 1;
     font-size: 1em;
-    color: var(--active-color);
+    color: var(--jactive-color);
     text-transform: uppercase;
     font-weight: bold;
     box-sizing: border-box;

--- a/src/style/core.css
+++ b/src/style/core.css
@@ -1,8 +1,8 @@
 :root {
-    --button-color: #298BA8; 
-    --active-color: #007aff;
-    --safe-area-top: env(safe-area-inset-top);
-    --safe-area-bottom: env(safe-area-inset-bottom);
+    --jbutton-color: #298BA8; 
+    --jactive-color: #007aff;
+    --jsafe-area-top: env(safe-area-inset-top);
+    --jsafe-area-bottom: env(safe-area-inset-bottom);
 }
 
 [data-visible="false"], .row[data-visible="false"] {
@@ -162,7 +162,7 @@ div[data-before]:before {
     display: none;
 }
 
-@keyframes fadeIn {
+@keyframes jfadeIn {
      0% {
           opacity: 0;
      }

--- a/src/style/core.css
+++ b/src/style/core.css
@@ -154,7 +154,7 @@ div[data-before]:before {
     margin: 10px;
 
     display: block;
-    animation: fadeIn 0.5s;
+    animation: jfadeIn 0.5s;
     pointer-events: none;
 }
 

--- a/src/style/dropdown.css
+++ b/src/style/dropdown.css
@@ -86,7 +86,7 @@
 .jdropdown-close {
     display:none;
     font-size:1em;
-    color: var(--active-color);
+    color: var(--jactive-color);
     text-transform:uppercase;
     text-align:right;
     padding:12px;

--- a/src/style/notification.css
+++ b/src/style/notification.css
@@ -70,7 +70,7 @@
 
 @media (max-width: 800px) {
     .jnotification {
-        top: calc(0px + var(--safe-area-top));
+        top: calc(0px + var(--jsafe-area-top));
         width: 100%;
     }
     .jnotification-container {

--- a/src/style/toolbar.css
+++ b/src/style/toolbar.css
@@ -95,7 +95,7 @@
 }
 
 .jtoolbar-mobile .jtoolbar-selected a, .jtoolbar-mobile .jtoolbar-selected i, .jtoolbar-mobile .jtoolbar-selected span {
-    color:var(--active-color) !important;
+    color:var(--jactive-color) !important;
     background-color:transparent;
 }
 


### PR DESCRIPTION
In https://github.com/discourse/discourse, we've started using jsuites along with jspreadsheet and have noticed a few naming collisions with CSS animations and CSS custom properties. 

In this PR I've added the `j` prefix, which will help these styles remain independent from whichever app or website they may be integrated with. 