### PR TITLE
Fix currency autoCasting mask for negative values

### DIFF
--- a/dist/jsuites.js
+++ b/dist/jsuites.js
@@ -9,7 +9,7 @@ var jSuites;
 /******/ (function() { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 195:
+/***/ 794:
 /***/ (function(module) {
 
 /**
@@ -358,7 +358,7 @@ var jSuites;
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be in strict mode.
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
 !function() {
 "use strict";
 
@@ -367,7 +367,7 @@ __webpack_require__.d(__webpack_exports__, {
   "default": function() { return /* binding */ jsuites; }
 });
 
-;// CONCATENATED MODULE: ./src/utils/dictionary.js
+;// ./src/utils/dictionary.js
 // Update dictionary
 var setDictionary = function(d) {
     if (! document.dictionary) {
@@ -393,7 +393,7 @@ var translate = function(t) {
 
 
 /* harmony default export */ var dictionary = ({ setDictionary, translate });
-;// CONCATENATED MODULE: ./src/utils/tracking.js
+;// ./src/utils/tracking.js
  const Tracking = function(component, state) {
     if (state === true) {
         window['jSuitesStateControl'] = window['jSuitesStateControl'].filter(function(v) {
@@ -414,7 +414,7 @@ var translate = function(t) {
 }
 
 /* harmony default export */ var tracking = (Tracking);
-;// CONCATENATED MODULE: ./src/utils/helpers.js
+;// ./src/utils/helpers.js
 var Helpers = {};
 
 // Two digits
@@ -583,7 +583,7 @@ Helpers.findElement = function(element, condition) {
 }
 
 /* harmony default export */ var helpers = (Helpers);
-;// CONCATENATED MODULE: ./src/utils/path.js
+;// ./src/utils/path.js
 const isValidPathObj = function(o) {
     return typeof o === 'object' || typeof o === 'function';
 }
@@ -671,7 +671,7 @@ function Path(pathString, value, remove) {
     currentObject[finalKey] = value;
     return true;
 }
-;// CONCATENATED MODULE: ./src/utils/sorting.js
+;// ./src/utils/sorting.js
 function Sorting(el, options) {
     var obj = {};
     obj.options = {};
@@ -828,7 +828,7 @@ function Sorting(el, options) {
 
     return el;
 }
-;// CONCATENATED MODULE: ./src/utils/lazyloading.js
+;// ./src/utils/lazyloading.js
 function LazyLoading(el, options) {
     var obj = {}
 
@@ -895,7 +895,7 @@ function LazyLoading(el, options) {
 
     return obj;
 }
-;// CONCATENATED MODULE: ./src/plugins/ajax.js
+;// ./src/plugins/ajax.js
 function Ajax() {
     var Component = (function(options, complete) {
         if (Array.isArray(options)) {
@@ -1208,7 +1208,7 @@ function Ajax() {
 }
 
 /* harmony default export */ var ajax = (Ajax());
-;// CONCATENATED MODULE: ./src/plugins/animation.js
+;// ./src/plugins/animation.js
 function Animation() {
     const Component = {
         loading: {}
@@ -1341,7 +1341,7 @@ function Animation() {
 }
 
 /* harmony default export */ var animation = (Animation());
-;// CONCATENATED MODULE: ./src/utils/helpers.date.js
+;// ./src/utils/helpers.date.js
 
 
 
@@ -1484,7 +1484,7 @@ function HelpersDate() {
 }
 
 /* harmony default export */ var helpers_date = (HelpersDate());
-;// CONCATENATED MODULE: ./src/plugins/mask.js
+;// ./src/plugins/mask.js
 /*
  Add '*' as a valid symbol
  Formats such as 'DD"th of "MMMM", "YYYY'
@@ -3269,17 +3269,19 @@ function Mask() {
         const original = input.trim();
 
         const isNegative = /^\s*[-(]/.test(original);
-        let value = original.replace(/[()\-\s]/g, '');
+        const hasParens = /^\s*\(.+\)\s*$/.test(original);
+        let value = original.replace(/[()\-]/g, '').trim();
 
         // Known symbols
         const knownSymbols = ['$', '€', '£', '¥', '₹', '₽', '₩', '₫', 'R$', 'CHF', 'AED'];
         let symbol = '';
 
         for (let s of knownSymbols) {
-            const regex = new RegExp(`^${s.replace(/[$]/g, '\\$')}(\\s?)`);
+            const escaped = s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+            const regex = new RegExp(`^${escaped}(\\s?)`);
             const match = value.match(regex);
             if (match) {
-                symbol = s + (match[1] || ' ');
+                symbol = s + (match[1] || '');
                 value = value.replace(regex, '');
                 break;
             }
@@ -3287,9 +3289,9 @@ function Mask() {
 
         // Generic symbol/prefix (e.g., "U$", "US$")
         if (!symbol) {
-            const prefixMatch = value.match(/^([^\d\s.,-]{1,4})\s?/);
+            const prefixMatch = value.match(/^([^\d\s.,-]{1,4})(\s?)/);
             if (prefixMatch) {
-                symbol = prefixMatch[1] + ' ';
+                symbol = prefixMatch[1] + (prefixMatch[2] || '');
                 value = value.replace(prefixMatch[0], '');
             }
         }
@@ -3300,6 +3302,8 @@ function Mask() {
             value = value.replace(codeMatch[1], '').trim();
             if (!symbol) symbol = codeMatch[1] + ' ';
         }
+
+        value = value.replace(/\s+/g, '');
 
         // Infer separators
         let group = ',', decimal = '.';
@@ -3350,7 +3354,11 @@ function Mask() {
         const decimalPlaces = normalized.includes('.') ? normalized.split('.')[1].length : 0;
         const maskDecimal = decimalPlaces ? decimal + '0'.repeat(decimalPlaces) : '';
         const groupMask = '#' + group + '##0';
-        const mask = `${symbol}${groupMask}${maskDecimal}`;
+        let mask = `${symbol}${groupMask}${maskDecimal}`;
+
+        if (isNegative) {
+            mask = hasParens ? `(${mask})` : `-${mask}`;
+        }
 
         return {
             mask,
@@ -3862,7 +3870,7 @@ console.log(o)
 
 /* harmony default export */ var mask = (Mask());
 
-;// CONCATENATED MODULE: ./src/plugins/calendar.js
+;// ./src/plugins/calendar.js
 
 
 
@@ -5011,7 +5019,7 @@ function Calendar() {
 }
 
 /* harmony default export */ var calendar = (Calendar());
-;// CONCATENATED MODULE: ./src/plugins/palette.js
+;// ./src/plugins/palette.js
 // More palettes https://coolors.co/ or https://gka.github.io/palettes/#/10|s|003790,005647,ffffe0|ffffe0,ff005e,93003a|1|1
 
 function Palette() {
@@ -5074,7 +5082,7 @@ function Palette() {
 }
 
 /* harmony default export */ var palette = (Palette());
-;// CONCATENATED MODULE: ./src/plugins/tabs.js
+;// ./src/plugins/tabs.js
 
 
 
@@ -5646,7 +5654,7 @@ function Tabs(el, options) {
 
     return obj;
 }
-;// CONCATENATED MODULE: ./src/plugins/color.js
+;// ./src/plugins/color.js
 
 
 
@@ -6346,7 +6354,7 @@ function Color(el, options) {
 
     return obj;
 }
-;// CONCATENATED MODULE: ./src/plugins/contextmenu.js
+;// ./src/plugins/contextmenu.js
 
 
 
@@ -6593,7 +6601,7 @@ function Contextmenu() {
 }
 
 /* harmony default export */ var contextmenu = (Contextmenu());
-;// CONCATENATED MODULE: ./src/plugins/dropdown.js
+;// ./src/plugins/dropdown.js
 
 
 
@@ -8403,7 +8411,7 @@ function Dropdown() {
 }
 
 /* harmony default export */ var dropdown = (Dropdown());
-;// CONCATENATED MODULE: ./src/plugins/picker.js
+;// ./src/plugins/picker.js
 
 
 
@@ -8733,7 +8741,7 @@ function Picker(el, options) {
 
     return obj;
 }
-;// CONCATENATED MODULE: ./src/plugins/toolbar.js
+;// ./src/plugins/toolbar.js
 
 
 
@@ -9046,7 +9054,7 @@ function Toolbar(el, options) {
 
     return obj;
 }
-;// CONCATENATED MODULE: ./src/plugins/editor.js
+;// ./src/plugins/editor.js
 
 
 
@@ -10380,7 +10388,7 @@ function Editor() {
 
 /* harmony default export */ var editor = (Editor());
 
-;// CONCATENATED MODULE: ./src/plugins/floating.js
+;// ./src/plugins/floating.js
 function Floating() {
     var Component = (function (el, options) {
         var obj = {};
@@ -10527,7 +10535,7 @@ function Floating() {
 }
 
 /* harmony default export */ var floating = (Floating());
-;// CONCATENATED MODULE: ./src/plugins/validations.js
+;// ./src/plugins/validations.js
 
 
 function Validations() {
@@ -10848,7 +10856,7 @@ function Validations() {
 }
 
 /* harmony default export */ var validations = (Validations());
-;// CONCATENATED MODULE: ./src/plugins/form.js
+;// ./src/plugins/form.js
 
 
 
@@ -11269,7 +11277,7 @@ function Form() {
 }
 
 /* harmony default export */ var plugins_form = (Form());
-;// CONCATENATED MODULE: ./src/plugins/modal.js
+;// ./src/plugins/modal.js
 
 
 
@@ -11555,7 +11563,7 @@ function Modal() {
 }
 
 /* harmony default export */ var modal = (Modal());
-;// CONCATENATED MODULE: ./src/plugins/notification.js
+;// ./src/plugins/notification.js
 
 
 
@@ -11704,7 +11712,7 @@ function Notification() {
 }
 
 /* harmony default export */ var notification = (Notification());
-;// CONCATENATED MODULE: ./src/plugins/progressbar.js
+;// ./src/plugins/progressbar.js
 function Progressbar(el, options) {
     var obj = {};
     obj.options = {};
@@ -11819,7 +11827,7 @@ function Progressbar(el, options) {
 
     return obj;
 }
-;// CONCATENATED MODULE: ./src/plugins/rating.js
+;// ./src/plugins/rating.js
 function Rating(el, options) {
     // Already created, update options
     if (el.rating) {
@@ -11963,7 +11971,7 @@ function Rating(el, options) {
 
     return obj;
 }
-;// CONCATENATED MODULE: ./src/plugins/search.js
+;// ./src/plugins/search.js
 
 
 
@@ -12248,7 +12256,7 @@ function Search(el, options) {
 
     return obj;
 }
-;// CONCATENATED MODULE: ./src/plugins/slider.js
+;// ./src/plugins/slider.js
 function Slider(el, options) {
     var obj = {};
     obj.options = {};
@@ -12470,7 +12478,7 @@ function Slider(el, options) {
 
     return obj;
 }
-;// CONCATENATED MODULE: ./src/plugins/tags.js
+;// ./src/plugins/tags.js
 
 
 
@@ -13168,7 +13176,7 @@ function Tags(el, options) {
 
     return obj;
 }
-;// CONCATENATED MODULE: ./src/plugins/upload.js
+;// ./src/plugins/upload.js
 
 
 
@@ -13456,9 +13464,9 @@ function Upload(el, options) {
 }
 
 // EXTERNAL MODULE: ./packages/sha512/sha512.js
-var sha512 = __webpack_require__(195);
+var sha512 = __webpack_require__(794);
 var sha512_default = /*#__PURE__*/__webpack_require__.n(sha512);
-;// CONCATENATED MODULE: ./src/jsuites.js
+;// ./src/jsuites.js
 
 
 


### PR DESCRIPTION
## Summary
- preserve parentheses and symbol spacing in auto-casting currency masks

## Testing
- `npm test` (7 failing, 4 skipped, 95 passing)


------
https://chatgpt.com/codex/tasks/task_e_6898ee23a4108323b00099cf8eadb781